### PR TITLE
Remove todo for dev / prod source maps as I decided to keep them for production debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ building initial project foundation / configuration
 # TODO
 
 - investigate dev / prod optimization tools
-- scss / ts source maps for dev only
 - implement react router
 - implement jest
 - implement error boundary

--- a/webpack/webpack.config.common.js
+++ b/webpack/webpack.config.common.js
@@ -39,7 +39,7 @@ module.exports = {
               modules: {
                 localIdentName: '[name]-[local]--[hash:base64:5]'
               },
-              sourceMap: true // dev only, but we'll keep it here for now and override in prod
+              sourceMap: true
             }
           },
           {


### PR DESCRIPTION
I initially started by trying to add a couple of rules to a new scss ruleset in my dev config,

this led me to an error because webpack merge has no intelligent logic for concatenating objects, so I ended up with two scss loaders for the same thing.

I learned that if I end up with some variation, I need to have a unique rule set within my dev / prod configs.

After testing with and without the source maps, I ultimately decided to keep them because it would make production debugging easier.

I also compared my devtool (js source maps) as they are different from dev & prod

the dev one bundles into your main bundle and the prod ones are separate which gives you the options of more fine grain control or using those specific maps with other debugging tools. This is why the build gives me those .map files as they are the source maps for your source codes split out as per request.

I am beginning to feel more confident with these types of configuration changes and the endless options they provide.