### PR TITLE
Add types path alias

### DIFF
--- a/src/components/examples/InputValidation/InputValidation.tsx
+++ b/src/components/examples/InputValidation/InputValidation.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, ChangeEvent } from 'react';
+import type User from '@types/user';
 import * as styles from './inputValidation.scss';
 
 export default function InputValidation() {

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,0 +1,4 @@
+declare type User = {
+  name: string;
+  age: number;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "paths": {
       "@components/*": ["components/*"],
       "@utils/*": ["utils/*"],
-      "@constants/*": ["constants/*"]
+      "@constants/*": ["constants/*"],
+      "@types/*": ["types/*"]
+
     },
     "outDir": "./dist/",
     "noImplicitAny": true,

--- a/webpack/webpack.config.common.js
+++ b/webpack/webpack.config.common.js
@@ -17,6 +17,8 @@ module.exports = {
       '@hooks': path.resolve(Paths.SRC_DIR, 'hooks/'),
       '@utils': path.resolve(Paths.SRC_DIR, 'utils/'),
       '@constants': path.resolve(Paths.SRC_DIR, 'constants/'),
+      '@types': path.resolve(Paths.SRC_DIR, 'types/'),
+
     }
   },
   module: {


### PR DESCRIPTION
Added types alias to webpack.config and tsconfig files, however importing to the InputValidation component errors out stating "TS6137: Cannot import type declaration files. Consider importing 'user' instead of '@types/user'."