### PR TITLE
Recursive file system component example

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,18 +15,15 @@ module.exports = {
     }
   },
   rules: {
-    'prettier/prettier': 'error',
+    'prettier/prettier': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
+    'react/react-in-jsx-scope': 'off',
+    'no-restricted-exports': ['error', { restrictedNamedExports: ['then'] }],
     'linebreak-style': [
       'error',
       process.platform === 'win32' ? 'windows' : 'unix'
     ],
-    'react/react-in-jsx-scope': 'off',
-    'no-restricted-exports': [
-      'error',
-      {
-        restrictedNamedExports: ['then']
-      }
-    ]
+    'react/function-component-definition': ['off']
   },
   overrides: [
     {

--- a/src/components/Application/Application.tsx
+++ b/src/components/Application/Application.tsx
@@ -1,10 +1,12 @@
-import InputValidation from '@components/examples/InputValidation';
+// import InputValidation from '@components/examples/InputValidation';
+import RecursiveFileSystem from '@components/examples/RecursiveFileSystem';
 import * as styles from './Application.scss';
 
 export default function Application() {
   return (
     <div className={styles.root}>
-      <InputValidation />
+      {/* <InputValidation /> */}
+      <RecursiveFileSystem />
     </div>
   );
 }

--- a/src/components/examples/RecursiveFileSystem/FolderItems.tsx
+++ b/src/components/examples/RecursiveFileSystem/FolderItems.tsx
@@ -1,0 +1,16 @@
+import * as styles from './RecursiveFileSystem.scss';
+import RecursiveFileSystem from './RecursiveFileSystem';
+
+const FolderItems = ({ folderItems }: any) => {
+  return folderItems.map((item: any) => {
+    if (item.folderItems) {
+      return (
+        <RecursiveFileSystem folderItems={item.folderItems} name={item.name} />
+      );
+    }
+
+    return <span className={styles.folderItem}>{item.name}</span>;
+  });
+};
+
+export default FolderItems;

--- a/src/components/examples/RecursiveFileSystem/RecursiveFileSystem.scss
+++ b/src/components/examples/RecursiveFileSystem/RecursiveFileSystem.scss
@@ -1,0 +1,25 @@
+.folderButton {
+  margin-bottom: 10px;
+  background-color: transparent;
+  border: none;
+
+  font-family: sans-serif;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+
+  padding: 0;
+}
+
+.folderItemWrapper {
+  display: flex;
+  flex-direction: column;
+  margin-left: 10px;
+}
+
+.folderItem {
+  margin-bottom: 10px;
+  font-family: sans-serif;
+  font-size: 14px;
+  font-style: italic;
+}

--- a/src/components/examples/RecursiveFileSystem/RecursiveFileSystem.tsx
+++ b/src/components/examples/RecursiveFileSystem/RecursiveFileSystem.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import * as styles from './RecursiveFileSystem.scss';
+
+import FolderItems from './FolderItems';
+
+const FILE_ONE = { name: 'file 1' };
+const FILE_TWO = { name: 'file 2' };
+const NESTED_FILE_ONE = { name: 'nested file 1' };
+const NESTED_FILE_TWO = { name: 'nested file 2' };
+
+const DATA = [
+  FILE_ONE,
+  FILE_TWO,
+  {
+    name: 'nested folder',
+    folderItems: [
+      NESTED_FILE_ONE,
+      { name: 'nested folder 2', folderItems: [NESTED_FILE_TWO] }
+    ]
+  }
+];
+
+const RecursiveFileSystem = ({
+  name = 'Top Level',
+  folderItems = DATA
+}: any) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const handleExpanded = () => setIsExpanded((prev) => !prev);
+
+  return (
+    <div>
+      <button
+        type="button"
+        className={styles.folderButton}
+        onClick={handleExpanded}
+      >
+        {name}
+      </button>
+      {isExpanded && (
+        <div className={styles.folderItemWrapper}>
+          <FolderItems folderItems={folderItems} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecursiveFileSystem;

--- a/src/components/examples/RecursiveFileSystem/index.ts
+++ b/src/components/examples/RecursiveFileSystem/index.ts
@@ -1,0 +1,3 @@
+import RecursiveFileSystem from './RecursiveFileSystem';
+
+export default RecursiveFileSystem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "react-jsx",
     "allowJs": true,
     "moduleResolution": "node",
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
I also modified some of the ESLint config to simply add some personal preferences to my development linting options.

This example is far from perfect, but introduces a recursive file system that can continuously render child folder structures.

The trick to this is to create a data structure that plays nicely with the overall system. The top level requires a name and some folder items to map through.

The component that renders the child item checks the current item for a `folderItems` property, if it exists, it renders the parent component and passes in the required props (name / folder items).

The only concern here is a circular dependency, which didn't appear to give me any issues, but it's something to be aware of.